### PR TITLE
Proper python3 support

### DIFF
--- a/debinterface/adapter.py
+++ b/debinterface/adapter.py
@@ -38,7 +38,7 @@ class NetworkAdapter:
     def validateAll(self):
         ''' Not thorough validations... and quick coded. Raise ValueError '''
 
-        for k, v in self._valid.iteritems():
+        for k, v in self._valid.items():
             val = None
             if k in self._ifAttributes:
                 val = self._ifAttributes[k]

--- a/debinterface/dnsmasqRange.py
+++ b/debinterface/dnsmasqRange.py
@@ -3,7 +3,8 @@ import copy
 import os
 import shutil
 import socket
-import toolutils
+
+import debinterface.toolutils as toolutils
 
 
 DEFAULT_CONFIG = {

--- a/debinterface/dnsmasqRange.py
+++ b/debinterface/dnsmasqRange.py
@@ -135,7 +135,7 @@ class DnsmasqRange(object):
         self.backup()
 
         with toolutils.atomic_write(path) as dnsmasq:
-            for k, v in self._config.iteritems():
+            for k, v in self._config.items():
                 if k == "dhcp-range":
                     if not v:
                         continue

--- a/debinterface/hostapd.py
+++ b/debinterface/hostapd.py
@@ -132,7 +132,7 @@ class Hostapd(object):
         self.backup()
 
         with toolutils.atomic_write(path) as hostapd:
-            for k, v in self._config.iteritems():
+            for k, v in self._config.items():
                 hostapd.write("{0}={1}\n".format(str(k).strip(), str(v).strip()))
 
     def controlService(self, action):

--- a/debinterface/hostapd.py
+++ b/debinterface/hostapd.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
 import shutil
-import toolutils
+
+import debinterface.toolutils as toolutils
 
 
 class Hostapd(object):

--- a/debinterface/interfaces.py
+++ b/debinterface/interfaces.py
@@ -1,8 +1,8 @@
 # A class representing the contents of /etc/network/interfaces
-from interfacesWriter import InterfacesWriter
-from interfacesReader import InterfacesReader
-from adapter import NetworkAdapter
-import toolutils
+from debinterface.interfacesWriter import InterfacesWriter
+from debinterface.interfacesReader import InterfacesReader
+from debinterface.adapter import NetworkAdapter
+import debinterface.toolutils as toolutils
 
 
 class Interfaces:

--- a/debinterface/interfacesReader.py
+++ b/debinterface/interfacesReader.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # A class representing the contents of /etc/network/interfaces
 
-from adapter import NetworkAdapter
+from debinterface.adapter import NetworkAdapter
 
 
 class InterfacesReader:

--- a/debinterface/interfacesWriter.py
+++ b/debinterface/interfacesWriter.py
@@ -77,7 +77,7 @@ class InterfacesWriter:
         try:
             adapter.validateAll()
         except ValueError as e:
-            print(e.message)
+            print(repr(e))
             raise
 
         ifAttributes = adapter.export()

--- a/debinterface/interfacesWriter.py
+++ b/debinterface/interfacesWriter.py
@@ -1,7 +1,8 @@
 # Write interface
 import shutil
 from string import Template
-import toolutils
+
+import debinterface.toolutils as toolutils
 
 
 class InterfacesWriter:

--- a/debinterface/interfacesWriter.py
+++ b/debinterface/interfacesWriter.py
@@ -183,7 +183,7 @@ class InterfacesWriter:
     def _write_unknown(self, interfaces, adapter, ifAttributes):
         """ Write unknowns options """
         try:
-            for k, v in ifAttributes['unknown'].iteritems():
+            for k, v in ifAttributes['unknown'].items():
                 if v:
                     d = dict(varient=k, value=str(v))
                     interfaces.write(self._cmd.substitute(d))

--- a/test/test_dnsmasqRange.py
+++ b/test/test_dnsmasqRange.py
@@ -20,7 +20,7 @@ class TestDnsmasqRange(unittest.TestCase):
     def test_read(self):
         self.maxDiff = None
         with tempfile.NamedTemporaryFile() as source:
-            source.write(DEFAULT_CONTENT.encode("utf8"))
+            source.write(DEFAULT_CONTENT.encode("ascii"))
             source.flush()
             dns = DnsmasqRange(source.name)
             dns.read()
@@ -33,7 +33,7 @@ class TestDnsmasqRange(unittest.TestCase):
             dns._config = copy.deepcopy(DEFAULT_CONFIG)
             dns.write()
             source.flush()
-            content = source.read().decode("utf8").replace("\n", "")
+            content = source.read().decode("ascii").replace("\n", "")
             for line in DEFAULT_CONTENT.split("\n"):
                 if not line or line == "\n":
                     continue
@@ -78,7 +78,7 @@ class TestDnsmasqRange(unittest.TestCase):
 
     def test_backup(self):
         with tempfile.NamedTemporaryFile() as source:
-            source.write(DEFAULT_CONTENT.encode("utf8"))
+            source.write(DEFAULT_CONTENT.encode("ascii"))
             source.flush()
             dns = DnsmasqRange(source.name)
             dns.backup()
@@ -87,7 +87,7 @@ class TestDnsmasqRange(unittest.TestCase):
     def test_restore(self):
         backup = tempfile.NamedTemporaryFile()
         conffile = tempfile.NamedTemporaryFile()
-        backup.write(DEFAULT_CONTENT.encode("utf8"))
+        backup.write(DEFAULT_CONTENT.encode("ascii"))
         backup.flush()
         dns = DnsmasqRange(conffile.name, backup.name)
         dns.restore()

--- a/test/test_dnsmasqRange.py
+++ b/test/test_dnsmasqRange.py
@@ -20,7 +20,7 @@ class TestDnsmasqRange(unittest.TestCase):
     def test_read(self):
         self.maxDiff = None
         with tempfile.NamedTemporaryFile() as source:
-            source.write(DEFAULT_CONTENT)
+            source.write(DEFAULT_CONTENT.encode("utf8"))
             source.flush()
             dns = DnsmasqRange(source.name)
             dns.read()
@@ -33,7 +33,7 @@ class TestDnsmasqRange(unittest.TestCase):
             dns._config = copy.deepcopy(DEFAULT_CONFIG)
             dns.write()
             source.flush()
-            content = source.read().replace("\n", "")
+            content = source.read().decode("utf8").replace("\n", "")
             for line in DEFAULT_CONTENT.split("\n"):
                 if not line or line == "\n":
                     continue
@@ -78,7 +78,7 @@ class TestDnsmasqRange(unittest.TestCase):
 
     def test_backup(self):
         with tempfile.NamedTemporaryFile() as source:
-            source.write(DEFAULT_CONTENT)
+            source.write(DEFAULT_CONTENT.encode("utf8"))
             source.flush()
             dns = DnsmasqRange(source.name)
             dns.backup()
@@ -87,7 +87,7 @@ class TestDnsmasqRange(unittest.TestCase):
     def test_restore(self):
         backup = tempfile.NamedTemporaryFile()
         conffile = tempfile.NamedTemporaryFile()
-        backup.write(DEFAULT_CONTENT)
+        backup.write(DEFAULT_CONTENT.encode("utf8"))
         backup.flush()
         dns = DnsmasqRange(conffile.name, backup.name)
         dns.restore()

--- a/test/test_dnsmasqRange.py
+++ b/test/test_dnsmasqRange.py
@@ -106,7 +106,7 @@ class TestDnsmasqRange(unittest.TestCase):
             "start": "118.118.10.50", "end": "118.118.10.230"
         }
         self.assertEqual(set(expected.keys()), set(info.keys()))
-        for expected_key, expected_value in expected.iteritems():
+        for expected_key, expected_value in expected.items():
             self.assertEqual(expected_value, info[expected_key])
 
     def test_update_range(self):
@@ -126,5 +126,5 @@ class TestDnsmasqRange(unittest.TestCase):
         )
         cur_range = dns.get_itf_range("wlan0")
         self.assertEqual(set(expected.keys()), set(cur_range.keys()))
-        for expected_key, expected_value in expected.iteritems():
+        for expected_key, expected_value in expected.items():
             self.assertEqual(expected_value, cur_range[expected_key])

--- a/test/test_hostapd.py
+++ b/test/test_hostapd.py
@@ -72,7 +72,7 @@ class TestHostapd(unittest.TestCase):
     def test_read(self):
         self.maxDiff = None
         with tempfile.NamedTemporaryFile() as source:
-            source.write(DEFAULT_CONTENT)
+            source.write(DEFAULT_CONTENT.encode("ascii"))
             source.flush()
             dns = Hostapd(source.name)
             dns.read()
@@ -85,7 +85,7 @@ class TestHostapd(unittest.TestCase):
             dns._config = DEFAULT_CONFIG
             dns.write()
             source.flush()
-            content = source.read().replace("\n", "")
+            content = source.read().decode("ascii").replace("\n", "")
             for line in DEFAULT_CONTENT.split("\n"):
                 if not line or line == "\n":
                     continue
@@ -102,7 +102,7 @@ class TestHostapd(unittest.TestCase):
 
     def test_backup(self):
         with tempfile.NamedTemporaryFile() as source:
-            source.write(DEFAULT_CONTENT)
+            source.write(DEFAULT_CONTENT.encode("ascii"))
             source.flush()
             dns = Hostapd(source.name)
             dns.backup()
@@ -111,7 +111,7 @@ class TestHostapd(unittest.TestCase):
     def test_restore(self):
         backup = tempfile.NamedTemporaryFile()
         conffile = tempfile.NamedTemporaryFile()
-        backup.write(DEFAULT_CONTENT)
+        backup.write(DEFAULT_CONTENT.encode("ascii"))
         backup.flush()
         dns = Hostapd(conffile.name, backup.name)
         dns.restore()


### PR DESCRIPTION
This integrates some proper python 3 support:

- use items() instead of iteritems()
- use absolute imports
- encoding of files in tests