### PR TITLE
BUG FIX: use append if there's no index instead of insert

### DIFF
--- a/debinterface/interfaces.py
+++ b/debinterface/interfaces.py
@@ -68,9 +68,9 @@ class Interfaces:
         adapter.validateAll()
 
         if index is None:
-            self._adapters.insert(index, adapter)
-        else:
             self._adapters.append(adapter)
+        else:
+            self._adapters.insert(index, adapter)
         return adapter
 
     def removeAdapter(self, index):


### PR DESCRIPTION
Hi, 

I found a simple bug in your debinterface code.
I think it should use append if there's no index for the adapter.

Hope you check.

Thank you.
