### PR TITLE
adapter: Fix option parsing

### DIFF
--- a/debinterface/adapter.py
+++ b/debinterface/adapter.py
@@ -312,7 +312,7 @@ class NetworkAdapter:
                 for key in options.keys():
                     if key == 'name':
                         self.setName(options[key])
-                    if key == 'addrFam':
+                    elif key == 'addrFam':
                         self.setAddrFam(options[key])
                     elif key == 'source':
                         self.setAddressSource(options[key])


### PR DESCRIPTION
name ended up as a unknown option due to not being part of the if/elif block.

Signed-off-by: Julian Scheel <julian@jusst.de>