### PR TITLE
toolutils: Fix atomic_write

### DIFF
--- a/debinterface/interfaces.py
+++ b/debinterface/interfaces.py
@@ -68,9 +68,9 @@ class Interfaces:
         adapter.validateAll()
 
         if index is None:
-            self._adapters.insert(index, adapter)
-        else:
             self._adapters.append(adapter)
+        else:
+            self._adapters.insert(index, adapter)
         return adapter
 
     def removeAdapter(self, index):

--- a/debinterface/toolutils.py
+++ b/debinterface/toolutils.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import shutil
 from contextlib import contextmanager
 import subprocess
 
@@ -39,9 +38,12 @@ def atomic_write(filepath):
         :param filepath: the file path to be opened
     """
 
-    with tempfile.NamedTemporaryFile() as tf:
+    # Put tmp file to same directory as target file, to allow atomic move
+    realpath = os.path.realpath(filepath)
+    tmppath = os.path.dirname(realpath)
+    with tempfile.NamedTemporaryFile(dir=tmppath, delete=False) as tf:
         with open(tf.name, mode='w+') as tmp:
             yield tmp
             tmp.flush()
             os.fsync(tmp.fileno())
-        shutil.copy(tf.name, filepath)
+        os.rename(tf.name, realpath)


### PR DESCRIPTION
Using shutil.copy is not atomic. The only guaranteed atomic operation is
os.rename, which requires source and target to be on the same filesystem.
Ensure this by resolving the real file path in case it is symlink and place
the tmp file in the same directory.

Signed-off-by: Julian Scheel <julian@jusst.de>