### PR TITLE
Multiple DNS Support

### DIFF
--- a/debinterface/adapterValidation.py
+++ b/debinterface/adapterValidation.py
@@ -152,8 +152,11 @@ class NetworkAdapterValidation(object):
             if validations['type'] == 'IP':
                 self.validate_ip(val, opt)
             elif validations['type'] == 'IPList':
-                for ip in val:
-                    self.validate_ip(ip, opt)
+                if isinstance(val, list):
+                    for ip in val:
+                        self.validate_ip(ip, opt)
+                else:
+                    self.validate_ip(val, opt)
             elif validations["type"] == "BROADCAST_IP":
                 self.validate_broadcast_ip(val, opt)
             else:

--- a/debinterface/adapterValidation.py
+++ b/debinterface/adapterValidation.py
@@ -153,7 +153,7 @@ class NetworkAdapterValidation(object):
                 self.validate_ip(val, opt)
             elif validations['type'] == 'IPList':
                 for ip in val:
-                self.validate_ip(ip, opt)
+                    self.validate_ip(ip, opt)
             elif validations["type"] == "BROADCAST_IP":
                 self.validate_broadcast_ip(val, opt)
             else:

--- a/debinterface/adapterValidation.py
+++ b/debinterface/adapterValidation.py
@@ -36,7 +36,7 @@ VALID_OPTS = {
     "oneshot": {"in": ["on", "off"]},
     "berr": {"in": ["on", "off"]},
     'bridge-opts': {'type': dict},
-    'dns-nameservers': {'type': 'IP'},
+    'dns-nameservers': {'type': 'IPList'},
     "mode": {"in": ["GRE", "IPIP"]},
     'scope': {'in': ['global', 'link', 'host', 'site', 'host']},
     'addrFam': {'in': ['inet', 'inet6', 'ipx', 'can']},
@@ -151,6 +151,9 @@ class NetworkAdapterValidation(object):
         if 'type' in validations:
             if validations['type'] == 'IP':
                 self.validate_ip(val, opt)
+            elif validations['type'] == 'IPList':
+                for ip in val:
+                self.validate_ip(ip, opt)
             elif validations["type"] == "BROADCAST_IP":
                 self.validate_broadcast_ip(val, opt)
             else:

--- a/debinterface/interfacesReader.py
+++ b/debinterface/interfacesReader.py
@@ -82,7 +82,9 @@ class InterfacesReader(object):
             elif sline[0] == 'hostapd':
                 self._adapters[self._context].setHostapd(sline[1])
             elif sline[0] == 'dns-nameservers':
-                self._adapters[self._context].setDnsNameservers(sline[1])
+                nameservers = sline
+                del nameservers[0]
+                self._adapters[self._context].setDnsNameservers(nameservers)
             elif sline[0].startswith('bridge') is True:
                 opt = sline[0].split('_')
                 sline.pop(0)

--- a/debinterface/interfacesReader.py
+++ b/debinterface/interfacesReader.py
@@ -84,6 +84,8 @@ class InterfacesReader(object):
             elif sline[0] == 'dns-nameservers':
                 nameservers = sline
                 del nameservers[0]
+                if len(nameservers) == 1:
+                    nameservers = nameservers[0]
                 self._adapters[self._context].setDnsNameservers(nameservers)
             elif sline[0].startswith('bridge') is True:
                 opt = sline[0].split('_')

--- a/debinterface/interfacesWriter.py
+++ b/debinterface/interfacesWriter.py
@@ -151,7 +151,8 @@ class InterfacesWriter(object):
                 value = ifAttributes[field]
                 if value and value != 'None':
                     if isinstance(value, list):
-                        d = dict(varient=field, value=" ".join(ifAttributes[field]))
+                        d = dict(varient=field, 
+                            value=" ".join(ifAttributes[field]))
                     else:
                         d = dict(varient=field, value=ifAttributes[field])
                     interfaces.write(self._cmd.substitute(d))

--- a/debinterface/interfacesWriter.py
+++ b/debinterface/interfacesWriter.py
@@ -150,7 +150,10 @@ class InterfacesWriter(object):
             try:
                 value = ifAttributes[field]
                 if value and value != 'None':
-                    d = dict(varient=field, value=ifAttributes[field])
+                    if isinstance(value, list):
+                        d = dict(varient=field, value=" ".join(ifAttributes[field]))
+                    else:
+                        d = dict(varient=field, value=ifAttributes[field])
                     interfaces.write(self._cmd.substitute(d))
             # Keep going if a field isn't provided.
             except KeyError:

--- a/debinterface/interfacesWriter.py
+++ b/debinterface/interfacesWriter.py
@@ -151,8 +151,8 @@ class InterfacesWriter(object):
                 value = ifAttributes[field]
                 if value and value != 'None':
                     if isinstance(value, list):
-                        d = dict(varient=field, 
-                            value=" ".join(ifAttributes[field]))
+                        d = dict(varient=field,
+                                 value=" ".join(ifAttributes[field]))
                     else:
                         d = dict(varient=field, value=ifAttributes[field])
                     interfaces.write(self._cmd.substitute(d))

--- a/test/interfaces2.txt
+++ b/test/interfaces2.txt
@@ -6,3 +6,13 @@ iface eth0 inet static
          broadcast       192.168.0.255
          gateway         192.168.0.254
          up ethtool -s eth0 wol g
+##########################################################
+#   Sample multiple DNS
+
+auto eth0
+iface eth0 inet static
+         address         192.168.0.250
+         netmask         255.255.255.0
+         broadcast       192.168.0.255
+         gateway         192.168.0.254
+         dns-namerservers 8.8.8.8 8.8.4.4

--- a/test/interfaces2.txt
+++ b/test/interfaces2.txt
@@ -9,11 +9,7 @@ iface eth0 inet static
 ##########################################################
 #   Sample multiple DNS
 
-auto eth1
-iface eth1 inet static
-         address         192.168.0.251
-         netmask         255.255.255.0
-         broadcast       192.168.0.255
-         gateway         192.168.0.254
-         dns-namerservers 8.8.8.8 8.8.4.4 4.2.2.2
-         up ethtool -s eth1 wol g
+iface eth2 inet static
+    address 10.1.20.10
+    netmask 255.255.255.0
+    dns-nameservers 8.8.8.8 8.8.4.4 4.2.2.2

--- a/test/interfaces2.txt
+++ b/test/interfaces2.txt
@@ -9,10 +9,11 @@ iface eth0 inet static
 ##########################################################
 #   Sample multiple DNS
 
-auto eth0
-iface eth0 inet static
-         address         192.168.0.250
+auto eth1
+iface eth1 inet static
+         address         192.168.0.251
          netmask         255.255.255.0
          broadcast       192.168.0.255
          gateway         192.168.0.254
-         dns-namerservers 8.8.8.8 8.8.4.4
+         dns-namerservers 8.8.8.8 8.8.4.4 4.2.2.2
+         up ethtool -s eth1 wol g

--- a/test/test_interfacesReader.py
+++ b/test/test_interfacesReader.py
@@ -36,7 +36,7 @@ class TestInterfacesReader(unittest.TestCase):
             None
         )
         self.assertNotEqual(eth1, None)
-        self.assertEqual(eth1.attributes["dns-nameservers"], ["8.8.8.8"])
+        self.assertEqual(eth1.attributes["dns-nameservers"], "8.8.8.8")
 
     def test_interfaces2(self):
         """All adapters should validate"""

--- a/test/test_interfacesReader.py
+++ b/test/test_interfacesReader.py
@@ -36,13 +36,13 @@ class TestInterfacesReader(unittest.TestCase):
             None
         )
         self.assertNotEqual(eth1, None)
-        self.assertEqual(eth1.attributes["dns-nameservers"], "8.8.8.8")
+        self.assertEqual(eth1.attributes["dns-nameservers"], ["8.8.8.8"])
 
     def test_interfaces2(self):
         """All adapters should validate"""
         reader = InterfacesReader(INF2_PATH)
         adapters = reader.parse_interfaces()
-        self.assertEqual(len(adapters), 1)
+        self.assertEqual(len(adapters), 2)
         for adapter in adapters:
             adapter.validateAll()
         self.assertEqual(adapters[0].attributes, {
@@ -67,7 +67,7 @@ class TestInterfacesReader(unittest.TestCase):
         """All adapters should validate"""
         reader = InterfacesReader(INF2_PATH)
         adapters = reader.parse_interfaces()
-        self.assertEqual(len(adapters), 1)
+        self.assertEqual(len(adapters), 2)
         for adapter in adapters:
             adapter.validateAll()
         self.assertEqual(adapters[1].attributes, {

--- a/test/test_interfacesReader.py
+++ b/test/test_interfacesReader.py
@@ -82,7 +82,7 @@ class TestInterfacesReader(unittest.TestCase):
             'down': [],
             'source': 'static',
             'netmask': '255.255.255.0',
-            'address': '192.168.0.250',
+            'address': '192.168.0.251',
             'pre-up': [],
             'post-down': [],
             'post-up': [],

--- a/test/test_interfacesReader.py
+++ b/test/test_interfacesReader.py
@@ -72,19 +72,16 @@ class TestInterfacesReader(unittest.TestCase):
             adapter.validateAll()
         self.assertEqual(adapters[1].attributes, {
             'addrFam': 'inet',
-            'broadcast': '192.168.0.255',
-            'name': 'eth0',
-            'auto': True,
-            'bridge-opts': {},
-            'up': [],
-            'dns-nameservers': ['8.8.8.8', '8.8.4.4', '4.2.2.2'],
-            'gateway': '192.168.0.254',
-            'down': [],
+            'name': 'eth2',
             'source': 'static',
+            'bridge-opts': {},
+            'dns-nameservers': ['8.8.8.8', '8.8.4.4', '4.2.2.2'],
             'netmask': '255.255.255.0',
-            'address': '192.168.0.251',
+            'address': '10.1.20.10',
+            'up': [],
+            'down': [],
             'pre-up': [],
-            'post-down': [],
+            'pre-down': [],
             'post-up': [],
-            'pre-down': []
+            'post-down': []
         })

--- a/test/test_interfacesReader.py
+++ b/test/test_interfacesReader.py
@@ -62,3 +62,29 @@ class TestInterfacesReader(unittest.TestCase):
             'post-up': [],
             'pre-down': []
         })
+
+    def test_multiDns_read(self):
+        """All adapters should validate"""
+        reader = InterfacesReader(INF2_PATH)
+        adapters = reader.parse_interfaces()
+        self.assertEqual(len(adapters), 1)
+        for adapter in adapters:
+            adapter.validateAll()
+        self.assertEqual(adapters[1].attributes, {
+            'addrFam': 'inet',
+            'broadcast': '192.168.0.255',
+            'name': 'eth0',
+            'auto': True,
+            'bridge-opts': {},
+            'up': [],
+            'dns-nameservers': ['8.8.8.8', '8.8.4.4', '4.2.2.2'],
+            'gateway': '192.168.0.254',
+            'down': [],
+            'source': 'static',
+            'netmask': '255.255.255.0',
+            'address': '192.168.0.250',
+            'pre-up': [],
+            'post-down': [],
+            'post-up': [],
+            'pre-down': []
+        })

--- a/test/test_interfacesWriter.py
+++ b/test/test_interfacesWriter.py
@@ -95,7 +95,7 @@ class TestInterfacesWriter(unittest.TestCase):
             'gateway': '192.168.0.254',
             'address': '192.168.0.250',
             'netmask': '255.255.255.0',
-            'dns-nameservers': '8.8.8.8'
+            'dns-nameservers': '8.8.8.8',
         }
 
         expected = [
@@ -105,7 +105,7 @@ class TestInterfacesWriter(unittest.TestCase):
             "netmask 255.255.255.0",
             "broadcast 192.168.0.255",
             "gateway 192.168.0.254",
-            "dns-nameservers 8.8.8.8"
+            "dns-nameservers 8.8.8.8",
             "up ethtool -s eth0 wol g",
         ]
         adapter = NetworkAdapter(options={})

--- a/test/test_interfacesWriter.py
+++ b/test/test_interfacesWriter.py
@@ -95,7 +95,7 @@ class TestInterfacesWriter(unittest.TestCase):
             'gateway': '192.168.0.254',
             'address': '192.168.0.250',
             'netmask': '255.255.255.0',
-            'dns-nameservers': '8.8.8.8',
+            'dns-nameservers': ['8.8.8.8'],
         }
 
         expected = [

--- a/test/test_interfacesWriter.py
+++ b/test/test_interfacesWriter.py
@@ -95,6 +95,7 @@ class TestInterfacesWriter(unittest.TestCase):
             'gateway': '192.168.0.254',
             'address': '192.168.0.250',
             'netmask': '255.255.255.0',
+            'dns-nameservers': '8.8.8.8'
         }
 
         expected = [
@@ -104,7 +105,42 @@ class TestInterfacesWriter(unittest.TestCase):
             "netmask 255.255.255.0",
             "broadcast 192.168.0.255",
             "gateway 192.168.0.254",
+            "dns-nameservers 8.8.8.8"
             "up ethtool -s eth0 wol g",
+        ]
+        adapter = NetworkAdapter(options={})
+        adapter._ifAttributes = options
+        with tempfile.NamedTemporaryFile() as tempf:
+            writer = InterfacesWriter([adapter], tempf.name)
+            writer.write_interfaces()
+
+            content = open(tempf.name).read().split("\n")
+            for line_written, line_expected in zip(content, expected):
+                self.assertEqual(line_written.strip(), line_expected)
+
+    def test_multiDns_write(self):
+        """Should work"""
+
+        options = {
+            'addrFam': 'inet',
+            'broadcast': '192.168.0.255',
+            'source': 'static',
+            'name': 'eth0',
+            'auto': True,
+            'gateway': '192.168.0.254',
+            'address': '192.168.0.250',
+            'netmask': '255.255.255.0',
+            'dns-nameservers': ['8.8.8.8', '8.8.4.4', '4.2.2.2']
+        }
+
+        expected = [
+            "auto eth0",
+            "iface eth0 inet static",
+            "address 192.168.0.250",
+            "netmask 255.255.255.0",
+            "broadcast 192.168.0.255",
+            "gateway 192.168.0.254",
+            "dns-nameservers 8.8.8.8 8.8.4.4 4.2.2.2",
         ]
         adapter = NetworkAdapter(options={})
         adapter._ifAttributes = options

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,6 @@ commands =
     flake8 debinterface
     py.test test
 [flake8]
+ignore=W503
 exclude = .tox,*.egg,build,data,deploy.sh
 select = E,W,F


### PR DESCRIPTION
Why:
Only one DNS IP was being read or written by the library.

This change addresses the need by:
Read DNS IPs into a list.
Check the validity of each one individually using validate_ip().
Write multiple DNS IPs to 'interfaces' if more than one exists.
Added tests to check multiple DNS IPs are read and written.

Continued issues:
I cannot get the tests to run using the current code, running 'sudo python setup.py test' results in an error referring to imports.