### PR TITLE
Add wpa-conf attribute to adapter

### DIFF
--- a/debinterface/adapter.py
+++ b/debinterface/adapter.py
@@ -257,6 +257,15 @@ class NetworkAdapter(object):
             'bridge-opts', VALID_OPTS['bridge-opts'], opts)
         self._ifAttributes['bridge-opts'] = opts
 
+    def setWpaConf(self, conf_path):
+        '''Set the wpa supplicant configuration path for supplicant
+        config for wireless interfaces.
+
+        Args:
+            conf_path (str): Path at which the supplicant config is located.
+        '''
+        self._ifAttributes['wpa-conf'] = conf_path
+
     def replaceBropt(self, key, value):
         """Set a discrete bridge option key with value
 
@@ -472,14 +481,18 @@ class NetworkAdapter(object):
                     'network': self.setNetwork,
                     'auto': self.setAuto,
                     'allow-hotplug': self.setHotplug,
+                    'hotplug': self.setHotplug,
                     'bridgeOpts': self.setBropts,
+                    'bridge-opts': self.setBropts,
                     'up': self.setUp,
                     'down': self.setDown,
                     'pre-up': self.setPreUp,
                     'pre-down': self.setPreDown,
                     'post-down': self.setPostDown,
                     'hostapd': self.setHostapd,
-                    'dns-nameservers': self.setDnsNameservers
+                    'dns-nameservers': self.setDnsNameservers,
+                    'dns-search': self.setDnsSearch,
+                    'wpa-conf': self.setWpaConf
                 }
                 for key, value in options.items():
                     if key in roseta:

--- a/debinterface/interfacesReader.py
+++ b/debinterface/interfacesReader.py
@@ -96,6 +96,8 @@ class InterfacesReader(object):
                 self._adapters[self._context].setNetwork(sline[1])
             elif sline[0] == 'hostapd':
                 self._adapters[self._context].setHostapd(sline[1])
+            elif sline[0] == 'wpa-conf':
+                self._adapters[self._context].setWpaConf(sline[1])
             elif sline[0] == 'dns-nameservers':
                 nameservers = sline
                 del nameservers[0]

--- a/debinterface/interfacesWriter.py
+++ b/debinterface/interfacesWriter.py
@@ -24,7 +24,7 @@ class InterfacesWriter(object):
     ]
     _prepFields = ['pre-up', 'up', 'down', 'pre-down', 'post-down']
     _bridgeFields = ['ports', 'fd', 'hello', 'maxage', 'stp', 'maxwait']
-    _plugins = ["hostapd"]
+    _plugins = ['hostapd', 'wpa-conf']
 
     def __init__(self, adapters, interfaces_path, backup_path=None,
                  header_comment=None):

--- a/test/interfaces.txt
+++ b/test/interfaces.txt
@@ -89,3 +89,7 @@ iface eth2 inet static
    gateway 172.20.1.1
    dns-nameservers 172.16.1.1 172.16.1.2
    dns-search mydomain.com myotherdomain.com
+
+auto wlan2
+iface wlan2 inet dhcp
+   wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf

--- a/test/test_adapter.py
+++ b/test/test_adapter.py
@@ -33,3 +33,50 @@ class TestNetworkAdapter(unittest.TestCase):
             'source': 'tunnel'
         }
         self.assertRaises(ValueError, NetworkAdapter, opts)
+
+    def test_assign_all_items(self):
+        cmds = ['ls']
+        options = {
+            'name': 'wlan0',
+            'addrFam': 'inet',
+            'source': 'static',
+            'netmask': '255.255.255.0',
+            'address': '10.10.10.10',
+            'gateway': '10.10.10.1',
+            'broadcast': '10.10.10.255',
+            'auto': True,
+            'hotplug': True,
+            'bridge-opts': {'maxwait': 1},
+            'up' : cmds,
+            'down': cmds,
+            'pre-up': cmds,
+            'pre-down': cmds,
+            'post-down': cmds,
+            'hostapd': '/etc/path/to/conf.conf',
+            'dns-nameservers': '10.10.10.2 10.10.10.3',
+            'dns-search': 'company.xyz',
+            'wpa-conf': '/etc/wpa_supplicant/wpa_supplicant.conf'
+        }
+
+        adapter = NetworkAdapter(options=options)
+        adapter.validateAll()
+
+        self.assertEqual(adapter.attributes['name'], 'wlan0')
+        self.assertEqual(adapter.attributes['addrFam'], 'inet')
+        self.assertEqual(adapter.attributes['source'], 'static')
+        self.assertEqual(adapter.attributes['netmask'], '255.255.255.0')
+        self.assertEqual(adapter.attributes['address'], '10.10.10.10')
+        self.assertEqual(adapter.attributes['gateway'], '10.10.10.1')
+        self.assertEqual(adapter.attributes['broadcast'], '10.10.10.255')
+        self.assertEqual(adapter.attributes['auto'], True)
+        self.assertEqual(adapter.attributes['hotplug'], True)
+        self.assertEqual(adapter.attributes['bridge-opts'], {'maxwait': 1})
+        self.assertEqual(adapter.attributes['up'], cmds)
+        self.assertEqual(adapter.attributes['down'], cmds)
+        self.assertEqual(adapter.attributes['pre-up'], cmds)
+        self.assertEqual(adapter.attributes['pre-down'], cmds)
+        self.assertEqual(adapter.attributes['post-down'], cmds)
+        self.assertEqual(adapter.attributes['hostapd'], '/etc/path/to/conf.conf')
+        self.assertEqual(adapter.attributes['dns-nameservers'], '10.10.10.2 10.10.10.3')
+        self.assertEqual(adapter.attributes['dns-search'], 'company.xyz')
+        self.assertEqual(adapter.attributes['wpa-conf'], '/etc/wpa_supplicant/wpa_supplicant.conf')

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -17,7 +17,7 @@ class TestInterfaces(unittest.TestCase):
         itfs = Interfaces(update_adapters=False, interfaces_path=INF_PATH)
         self.assertEqual(len(itfs.adapters), 0)
         itfs.updateAdapters()
-        self.assertEqual(len(itfs.adapters), 9)
+        self.assertEqual(len(itfs.adapters), 10)
 
     def test_get_existing_adapter(self):
         itfs = Interfaces(interfaces_path=INF_PATH)

--- a/test/test_interfacesReader.py
+++ b/test/test_interfacesReader.py
@@ -13,7 +13,7 @@ class TestInterfacesReader(unittest.TestCase):
     def test_parse_interfaces_count(self):
         """Should have 9 adapters"""
 
-        nb_adapters = 9
+        nb_adapters = 10
         reader = InterfacesReader(INF_PATH)
         adapters = reader.parse_interfaces()
         self.assertEqual(len(adapters), nb_adapters)
@@ -162,3 +162,11 @@ class TestInterfacesReader(unittest.TestCase):
                                                   'pre-up': [],
                                                   'source': 'loopback',
                                                   'up': []})
+
+    def test_read_wpa_conf(self):
+        reader = InterfacesReader(INF_PATH)
+        wlan2 = next(
+            (x for x in reader.parse_interfaces() if x.attributes['name'] == 'wlan2'),
+            None
+        )
+        self.assertEqual(wlan2.attributes['wpa-conf'], '/etc/wpa_supplicant/wpa_supplicant.conf')

--- a/test/test_interfacesWriter.py
+++ b/test/test_interfacesWriter.py
@@ -118,6 +118,32 @@ class TestInterfacesWriter(unittest.TestCase):
             for line_written, line_expected in zip(content, expected):
                 self.assertEqual(line_written.strip(), line_expected)
 
+    def test_supplicant_conf_write(self):
+        '''Test what wpa-conf is written out.'''
+
+        options = {
+            'addrFam': 'inet',
+            'source': 'dhcp',
+            'name': 'wlan0',
+            'auto': True,
+            'wpa-conf': '/etc/wpa_supplicant/wpa_supplicant.conf'
+        }
+
+        expected = [
+            "auto wlan0",
+            "iface wlan0 inet dhcp",
+            "wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf"
+        ]
+        adapter = NetworkAdapter(options)
+        with tempfile.NamedTemporaryFile() as tempf:
+            writer = InterfacesWriter([adapter], tempf.name)
+            writer.write_interfaces()
+
+            content = open(tempf.name).read().split("\n")
+            print(content)
+            for line_written, line_expected in zip(content, expected):
+                self.assertEqual(line_written.strip(), line_expected)
+
     def test_multiDns_write(self):
         """Should work"""
 
@@ -144,8 +170,7 @@ class TestInterfacesWriter(unittest.TestCase):
             "dns-nameservers 8.8.8.8 8.8.4.4 4.2.2.2",
             "dns-search mydomain.com myotherdomain.com"
         ]
-        adapter = NetworkAdapter(options={})
-        adapter._ifAttributes = options
+        adapter = NetworkAdapter(options)
         with tempfile.NamedTemporaryFile() as tempf:
             writer = InterfacesWriter([adapter], tempf.name)
             writer.write_interfaces()


### PR DESCRIPTION
Added `wpa-conf` to adapter and reader/writer.

Also added parsing of options dict as `bridge-opts` as this is the
true attribute title when reading it back from `attributes` accessor.

Added existing parsing of set_options for `dns-search` also.